### PR TITLE
Add recolor template build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ templates/*
 
 !/templates/config.yaml
 !/templates/default.mustache
+!/templates/recolor.mustache

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 BUILD=pybase16
 REPO=$(shell pwd)
 TEMPLATE=$(shell basename ${REPO})
-THEME_DIR=build_schemes
+BUILD_DIR=build_schemes
 TEMPLATE_DIR=templates
 OUTPUT=output
 
@@ -15,8 +15,9 @@ update:
 
 build:
 	$(BUILD) build -t ${REPO} -o ${OUTPUT}
-	rm -rf ${THEME_DIR}
-	mv ${OUTPUT}/${TEMPLATE}/${THEME_DIR}/ ${THEME_DIR}/
+	rm -rf ${BUILD_DIR}
+	mkdir ${BUILD_DIR}
+	cat templates/config.yaml | grep output | cut -d' ' -f6 | xargs -L1 -I {} mv ${OUTPUT}/${TEMPLATE}/{}/ ${BUILD_DIR}/
 
 clean:
 	rm -rf ${OUTPUT} ${TEMPLATE_DIR}/*/

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -1,3 +1,7 @@
 default:
     extension: .config
-    output: build_schemes 
+    output: colors
+
+recolor:
+    extension: .config
+    output: recolors

--- a/templates/recolor.mustache
+++ b/templates/recolor.mustache
@@ -1,0 +1,32 @@
+# Base16 {{scheme-name}}
+# Author: {{scheme-author}}
+
+set default-bg                  "#{{base00-hex}}"
+set default-fg                  "#{{base01-hex}}"
+
+set statusbar-fg                "#{{base04-hex}}"
+set statusbar-bg                "#{{base02-hex}}"
+
+set inputbar-bg                 "#{{base00-hex}}"
+set inputbar-fg                 "#{{base07-hex}}"
+
+set notification-bg             "#{{base00-hex}}"
+set notification-fg             "#{{base07-hex}}"
+
+set notification-error-bg       "#{{base00-hex}}"
+set notification-error-fg       "#{{base08-hex}}"
+
+set notification-warning-bg     "#{{base00-hex}}"
+set notification-warning-fg     "#{{base08-hex}}"
+
+set highlight-color             "#{{base0A-hex}}"
+set highlight-active-color      "#{{base0D-hex}}"
+
+set completion-bg               "#{{base01-hex}}"
+set completion-fg               "#{{base0D-hex}}"
+
+set completion-highlight-fg     "#{{base07-hex}}"
+set completion-highlight-bg     "#{{base0D-hex}}"
+
+set recolor-lightcolor          "#{{base00-hex}}"
+set recolor-darkcolor           "#{{base06-hex}}"


### PR DESCRIPTION
Like discussed on #1 added an alternative template build that doesn't tamper with the recolor flags.

Not sure if you mind, but I've also changed the default build folder to `colors` (which is common across template repos). 
It also gave me a chance to name the directory for new build as `recolor`, as I had no idea what I was going to name it, ahaha.

Let me know, if there's something that needs changing in the PR.

Resolves #1.